### PR TITLE
Add short array syntax support

### DIFF
--- a/indent/php.vim
+++ b/indent/php.vim
@@ -1223,7 +1223,7 @@ function! GetPhpIndent()
 
 	" if the last line is a [{(]$ or a multiline function call (or array
 	" declaration) with already one parameter on the opening ( line
-	if last_line =~# '[{(]'.endline || last_line =~? '\h\w*\s*(.*,$' && AntepenultimateLine !~ '[,(]'.endline
+	if last_line =~# '[{(\[]'.endline || last_line =~? '\h\w*\s*(.*,$' && AntepenultimateLine !~ '[,(]'.endline
 
 	    if !b:PHP_BracesAtCodeLevel || last_line !~# '^\s*{'
 		let ind = ind + &sw
@@ -1279,7 +1279,7 @@ function! GetPhpIndent()
     "echo "end"
     "call getchar()
     " If the current line closes a multiline function call or array def
-    if cline =~  '^\s*);\='
+    if cline =~  '^\s*[)\]];\='
 	let ind = ind - &sw
     endif
 


### PR DESCRIPTION
Support indenting of the short array syntax introduced in PHP 5.4, which may or may not break existing functionality. Could really benefit from a review by somebody more experienced.
