### PR TITLE
fix a bug for inline script element

### DIFF
--- a/indent/php.vim
+++ b/indent/php.vim
@@ -815,7 +815,7 @@ function! GetPhpIndent()
 	    let b:InPHPcode = 0
 	    let b:UserIsTypingComment = 0
 	    " Then we have to find a php start tag...
-	    let b:InPHPcode_tofind = '<?\%(.*?>\)\@!\|<script.*>'
+	    let b:InPHPcode_tofind = s:PHP_startindenttag
 	endif
     endif "!b:InPHPcode_checked }}}
 


### PR DESCRIPTION
Well, sometimes we have to mix HTML with PHP :(
If there's a line like: "<script src='example.js'></script >",
the HTML codes under this line may be incorrectly indented.
