### PR TITLE
Add final keyword

### DIFF
--- a/indent/php.vim
+++ b/indent/php.vim
@@ -656,7 +656,7 @@ function! IslinePHP (lnum, tofind) " {{{
 endfunction " }}}
 
 let s:notPhpHereDoc = '\%(break\|return\|continue\|exit\|die\|else\)'
-let s:blockstart = '\%(\%(\%(}\s*\)\=else\%(\s\+\)\=\)\=if\>\|else\>\|while\>\|switch\>\|case\>\|default\>\|for\%(each\)\=\>\|declare\>\|class\>\|interface\>\|abstract\>\|try\>\|catch\>\)'
+let s:blockstart = '\%(\%(\%(}\s*\)\=else\%(\s\+\)\=\)\=if\>\|else\>\|while\>\|switch\>\|case\>\|default\>\|for\%(each\)\=\>\|declare\>\|class\>\|interface\>\|abstract\>\|final\>\|try\>\|catch\>\)'
 
 " make sure the options needed for this script to work correctly are set here
 " for the last time. They could have been overridden by any 'onevent'


### PR DESCRIPTION
When a class is declared final and has a namespace then the class braces are incorrectly indented:

``` php
<?php
/**
 * Braces are incorrectly indented
 */
namespace Test;

final class One
{
}
```

to

``` php
<?php
/**
 * Braces are incorrectly indented
 */
namespace Test;

final class One
    {
    }
```

Adding final to block start seems to be the way to fix it.
