### PR TITLE
Changes &filetype check for matching php pattern

### DIFF
--- a/indent/php.vim
+++ b/indent/php.vim
@@ -459,7 +459,7 @@ let s:PHP_startindenttag = '<?\%(.*?>\)\@!\|<script[^>]*>\%(.*<\/script>\)\@!'
 let s:escapeDebugStops = 0
 function! DebugPrintReturn(scriptLine)
 
-    if ! s:escapeDebugStops 
+    if ! s:escapeDebugStops
 	echo "debug:" . a:scriptLine
 	let c = getchar()
 	if c == "\<Del>"
@@ -597,7 +597,7 @@ function! FindOpenBracket(lnum, blockStarter) " {{{
     let line = searchpair('{', '', '}', 'bW', 'Skippmatch()')
 
     if a:blockStarter == 1
-	while line > 1 
+	while line > 1
 	    let linec = getline(line)
 
 	    if linec =~ s:terminated || linec =~ '^\s*\%(' . s:blockstart . '\)\|'. s:functionDecl . s:endline
@@ -758,7 +758,7 @@ if ! s:autoresetoptions
 endif
 
 function! ResetPhpOptions()
-    if ! b:optionsset && &filetype == "php"
+    if ! b:optionsset && &filetype =~ "php"
 	if b:PHP_autoformatcomment
 
 	    " Set the comment setting to something correct for PHP


### PR DESCRIPTION
Eg:- Setting php.wordpress implies php syntax highlighting with
wordpress extensions.

With the equality check PHP indent settings stop working as it does not
detect the buffer as a PHP buffer.

Using a pattern match ensures that plugins that extend the php filetype
with custom syntax highlighting work correctly.
