### PR TITLE
Check shiftwidth() instead of 'shiftwidth'

### DIFF
--- a/indent/php.vim
+++ b/indent/php.vim
@@ -386,17 +386,29 @@ let b:did_indent = 1
 
 let g:php_sync_method = 0
 
+" Get the effective value of 'shiftwidth'. Vim since 7.3-703 allows a value of
+" 0, which uses the value of 'tabstop', in which case we need to use the
+" shiftwidth() function.
+if exists('*shiftwidth')
+  function! s:sw()
+    return shiftwidth()
+  endfunction
+else
+  function! s:sw()
+    return &shiftwidth
+  endfunction
+endif
 
 " Apply options
 
 if exists("PHP_default_indenting")
-    let b:PHP_default_indenting = PHP_default_indenting * &sw
+    let b:PHP_default_indenting = PHP_default_indenting * s:sw()
 else
     let b:PHP_default_indenting = 0
 endif
 
 if exists("PHP_outdentSLComments")
-    let b:PHP_outdentSLComments = PHP_outdentSLComments * &sw
+    let b:PHP_outdentSLComments = PHP_outdentSLComments * s:sw()
 else
     let b:PHP_outdentSLComments = 0
 endif
@@ -700,7 +712,7 @@ function! FindTheSwitchIndent (lnum) " {{{
     let test = GetLastRealCodeLNum(a:lnum - 1)
 
     if test <= 1
-	return indent(1) - &sw * b:PHP_vintage_case_default_indent
+	return indent(1) - s:sw() * b:PHP_vintage_case_default_indent
     end
 
     " A closing bracket? let skip the whole block to save some recursive calls
@@ -722,7 +734,7 @@ function! FindTheSwitchIndent (lnum) " {{{
 	return indent(test)
     elseif getline(test) =~# s:defaultORcase
 	" DEBUG call DebugPrintReturn('found a default/case on ' . test)
-	return indent(test) - &sw * b:PHP_vintage_case_default_indent
+	return indent(test) - s:sw() * b:PHP_vintage_case_default_indent
     else
 	" DEBUG call DebugPrintReturn('recursing from ' . test)
 	return FindTheSwitchIndent(test)
@@ -822,7 +834,7 @@ function! GetPhpIndent()
     endif
 
     if b:PHP_default_indenting
-	let b:PHP_default_indenting = g:PHP_default_indenting * &sw
+	let b:PHP_default_indenting = g:PHP_default_indenting * s:sw()
     endif
 
     " current line
@@ -1183,7 +1195,7 @@ function! GetPhpIndent()
     elseif cline =~# s:defaultORcase
 	" DEBUG call DebugPrintReturn(1064)
 	" case and default need a special treatment
-	return FindTheSwitchIndent(v:lnum) + &sw * b:PHP_vintage_case_default_indent
+	return FindTheSwitchIndent(v:lnum) + s:sw() * b:PHP_vintage_case_default_indent
     elseif cline =~ '^\s*)\=\s*{'
 	let previous_line = last_line
 	let last_line_num = lnum
@@ -1198,7 +1210,7 @@ function! GetPhpIndent()
 
 		" If the PHP_BracesAtCodeLevel is set then indent the '{'
 		if  b:PHP_BracesAtCodeLevel
-		    let ind = ind + &sw
+		    let ind = ind + s:sw()
 		endif
 
 		" DEBUG call DebugPrintReturn(1083)
@@ -1210,7 +1222,7 @@ function! GetPhpIndent()
 	endwhile
 
     elseif last_line =~# unstated && cline !~ '^\s*);\='.endline
-	let ind = ind + &sw " we indent one level further when the preceding line is not stated
+	let ind = ind + s:sw() " we indent one level further when the preceding line is not stated
 	" DEBUG call DebugPrintReturn(1093)
 	return ind + addSpecial
 
@@ -1394,7 +1406,7 @@ function! GetPhpIndent()
 	    " indent if we don't want braces at code level or if the last line
 	    " is not a lonely '{' (default indent for the if block)
 	    if !dontIndent && (!b:PHP_BracesAtCodeLevel || last_line !~# '^\s*{')
-		let ind = ind + &sw
+		let ind = ind + s:sw()
 	    endif
 
 	    if b:PHP_BracesAtCodeLevel || b:PHP_vintage_case_default_indent == 1
@@ -1421,7 +1433,7 @@ function! GetPhpIndent()
 	    " if the line before starts a block then we need to indent the
 	    " current line.
 	elseif last_line =~ '^\s*'.s:blockstart
-	    let ind = ind + &sw
+	    let ind = ind + s:sw()
 
 	    " In all other cases if !LastLineClosed indent 1 level higher
 	    " _only_ if the ante-penultimate line _is_ 'closed' or if it's a
@@ -1431,7 +1443,7 @@ function! GetPhpIndent()
 	    " were in this "list"
 
     elseif AntepenultimateLine =~ '{'.endline || AntepenultimateLine =~ terminated || AntepenultimateLine =~# s:defaultORcase
-	    let ind = ind + &sw
+	    let ind = ind + s:sw()
 	    " DEBUG call DebugPrintReturn(1422 . '  ' . AntepenultimateLine)
 	endif
 
@@ -1439,7 +1451,7 @@ function! GetPhpIndent()
 
     " If the current line closes a multiline function call or array def
     if cline =~  '^\s*[)\]];\='
-	let ind = ind - &sw
+	let ind = ind - s:sw()
     endif
 
     let b:PHP_CurrentIndentLevel = ind


### PR DESCRIPTION
Newer Vims allow a `'shiftwidth'` of `0`, which uses the `'tabstop'` value.

In the current version of the script, indentation fails when
`&shiftwidth` is `0`. Therefore use `shiftwidth()` to get the effective
value when available. See `:help shiftwidth()` for details.