### PR TITLE
PHP_IndentFunctionParameters -> PHP_IndentFunctionCallParameters, + PHP_IndentFunctionDeclarationParameters

### DIFF
--- a/doc/PHPIndent.txt
+++ b/doc/PHPIndent.txt
@@ -132,4 +132,22 @@ Function call arguments will indent 1 extra level. For two-space indentation: >
       );
     }
 
+-------------
+
+							*PHP_IndentFunctionDeclarationParameters*
+Extra indentation levels to add to arguments in multi-line function definitions. >
+    let g:PHP_IndentFunctionDeclarationParameters = 1
+
+Function arguments in declarations will indent 1 extra level. For two-space indentation: >
+
+    function call_the_thing(
+        $with_this,
+        $and_that
+    ) {
+      $this->do_the_thing(
+        $with_this,
+        $and_that
+      );
+    }
+
 vim:tw=78:ts=8:ft=help:norl:

--- a/doc/PHPIndent.txt
+++ b/doc/PHPIndent.txt
@@ -114,5 +114,22 @@ You will obtain the following result: >
         ->age()
         ->info();
 
+-------------
+
+							*PHP_IndentFunctionCallParameters*
+Extra indentation levels to add to parameters in multi-line function calls. >
+    let g:PHP_IndentFunctionCallParameters = 1
+
+Function call arguments will indent 1 extra level. For two-space indentation: >
+
+    function call_the_thing(
+      $with_this,
+      $and_that
+    ) {
+      $this->do_the_thing(
+          $with_this,
+          $and_that
+      );
+    }
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/indent/php.vim
+++ b/indent/php.vim
@@ -490,6 +490,12 @@ else
     let b:PHP_IndentFunctionCallParameters = 0
 endif
 
+if exists("PHP_IndentFunctionDeclarationParameters")
+    let b:PHP_IndentFunctionDeclarationParameters = PHP_IndentFunctionDeclarationParameters
+else
+    let b:PHP_IndentFunctionDeclarationParameters = 0
+endif
+
 let b:PHP_lastindented = 0
 let b:PHP_indentbeforelast = 0
 let b:PHP_indentinghuge = 0
@@ -539,7 +545,9 @@ let s:endline = '\s*\%(//.*\|#.*\|/\*.*\*/\s*\)\=$'
 let s:PHP_validVariable = '[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*'
 let s:notPhpHereDoc = '\%(break\|return\|continue\|exit\|die\|else\|end\%(if\|while\|for\|foreach\|switch\)\)'
 let s:blockstart = '\%(\%(\%(}\s*\)\=else\%(\s\+\)\=\)\=if\>\|\%(}\s*\)\?else\>\|do\>\|while\>\|switch\>\|case\>\|default\>\|for\%(each\)\=\>\|declare\>\|class\>\|trait\>\|\%()\s*\)\=use\>\|interface\>\|abstract\>\|final\>\|try\>\|\%(}\s*\)\=catch\>\|\%(}\s*\)\=finally\>\)'
-let s:functionDecl = '\<function\>\%(\s\+&\='.s:PHP_validVariable.'\)\=\s*(.*'
+let s:functionDeclPrefix = '\<function\>\%(\s\+&\='.s:PHP_validVariable.'\)\=\s*('
+let s:functionDecl = s:functionDeclPrefix.'.*'
+let s:multilineFunctionDecl = s:functionDeclPrefix.s:endline
 let s:arrayDecl = '\<array\>\s*(.*'
 let s:multilineFunctionCall = s:PHP_validVariable.'\s*('.s:endline
 " Unstated line?
@@ -1622,6 +1630,10 @@ function! GetPhpIndent()
 
 	    if b:PHP_IndentFunctionCallParameters && last_line =~ s:multilineFunctionCall && last_line !~ s:structureHead && last_line !~ s:arrayDecl
 		let ind = ind + b:PHP_IndentFunctionCallParameters * shiftwidth()
+	    endif
+
+	    if b:PHP_IndentFunctionDeclarationParameters && last_line =~ s:multilineFunctionDecl
+		let ind = ind + b:PHP_IndentFunctionDeclarationParameters * shiftwidth()
 	    endif
 
 	    if b:PHP_BracesAtCodeLevel || b:PHP_vintage_case_default_indent == 1

--- a/indent/php.vim
+++ b/indent/php.vim
@@ -484,10 +484,10 @@ else
     let b:PHP_vintage_case_default_indent = 0
 endif
 
-if exists("PHP_IndentFunctionParameters ")
-    let b:PHP_IndentFunctionParameters = PHP_IndentFunctionParameters
+if exists("PHP_IndentFunctionCallParameters")
+    let b:PHP_IndentFunctionCallParameters = PHP_IndentFunctionCallParameters
 else
-    let b:PHP_IndentFunctionParameters = 0
+    let b:PHP_IndentFunctionCallParameters = 0
 endif
 
 let b:PHP_lastindented = 0
@@ -1620,8 +1620,8 @@ function! GetPhpIndent()
 		" DEBUG call DebugPrintReturn(1454. '  +1 indent: '.ind)
 	    endif
 
-	    if b:PHP_IndentFunctionParameters && last_line =~ s:multilineFunctionCall && last_line !~ s:structureHead && last_line !~ s:arrayDecl
-		let ind = ind + b:PHP_IndentFunctionParameters * shiftwidth()
+	    if b:PHP_IndentFunctionCallParameters && last_line =~ s:multilineFunctionCall && last_line !~ s:structureHead && last_line !~ s:arrayDecl
+		let ind = ind + b:PHP_IndentFunctionCallParameters * shiftwidth()
 	    endif
 
 	    if b:PHP_BracesAtCodeLevel || b:PHP_vintage_case_default_indent == 1


### PR DESCRIPTION
Since the setting `PHP_IndentFunctionParameters` only works on function calls and not declarations, add a separately configurable `PHP_IndentFunctionDeclarationParameters` to control the indentation for those, as well.

Add to documentation.

This changeset includes the documentation change in #72, as well.